### PR TITLE
Add backend https support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ change this.
 #### Self signed SSL Certificate
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -p 8443:443 \
            quay.io/ukhomeofficedigital/nginx-proxy:v1.0.0
@@ -95,7 +95,7 @@ docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
 #### Custom SSL Certificate
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -p 8443:443 \
            -v /path/to/key:/etc/keys/key:ro \
@@ -117,7 +117,7 @@ To use this feature you will need:
   then a suitable range would be 10.50.0.0/22 see [CIDR Calculator](http://www.subnet-calculator.com/cidr.php).
   
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -e 'LOAD_BALANCER_CIDR=10.50.0.0/22' \
            -p 8443:443 \
@@ -130,7 +130,7 @@ The example below allows large documents to be POSTED to the /documents/uploads 
 See [Whitelist NAXSI rules](https://github.com/nbs-system/naxsi/wiki/whitelists) for more examples.
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=myapp.svc.cluster.local' \
+docker run -e 'PROXY_SERVICE_HOST=http://myapp.svc.cluster.local' \
            -e 'PROXY_SERVICE_PORT=8080' \
            -e 'EXTRA_NAXSI_RULES=BasicRule wl:2 "mz:$URL:/documents/uploads|BODY";
                BasicRule wl:2 "mz:$URL:/documents/other_uploads|BODY";' \
@@ -149,9 +149,9 @@ controlled with the use of any [Multi-location Variables](#multi-location-variab
 The example below configures a simple proxy with two locations '/' (location 1) and '/api' (location 2):
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST_1=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST_1=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT_1=80' \
-           -e 'PROXY_SERVICE_HOST_2=api.svc.cluster.local' \
+           -e 'PROXY_SERVICE_HOST_2=https://api.svc.cluster.local' \
            -e 'PROXY_SERVICE_PORT_2=8888' \
            -e 'LOCATIONS_CSV=/,/api' \
            -p 8443:443 \
@@ -168,7 +168,7 @@ The example below will proxy the same address for two locations but will disable
 See the [generated config](./docs/GeneratedConfigs.md#same-server-proxied) for below:
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -e 'LOCATIONS_CSV=/,/about' \
            -e 'ENABLE_UUID_PARAM_2=FALSE' \
@@ -181,7 +181,7 @@ docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
 If a client CA certificate is mounted, the proxy will be configured to load it. If a client has the cert, the client CN
 will be set in the X-Username header and logged.
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -v "${PWD}/client_certs/ca.crt:/etc/keys/client-ca" \
            -p 8443:443 \
@@ -191,7 +191,7 @@ docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
 The following example will specifically deny access to clients without a cert:
 
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=serverfault.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://serverfault.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -e 'LOCATIONS_CSV=/,/about' \
            -e 'CLIENT_CERT_REQUIRED_2=TRUE' \
@@ -205,7 +205,7 @@ See [./client_certs](./client_certs) for scripts that can be used to generate a 
 
 The example below will return "ping ok" for the URL /ping.
 ```shell
-docker run -e 'PROXY_SERVICE_HOST=stackexchange.com' \
+docker run -e 'PROXY_SERVICE_HOST=http://stackexchange.com' \
            -e 'PROXY_SERVICE_PORT=80' \
            -e 'ADD_NGINX_LOCATION_CFG=if ($uri = /proxy-ping) return 200 "ping ok";' \
            -p 8443:443 \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -89,20 +89,27 @@ echo "TESTING..."
 echo "=========="
 
 start_test "Start with minimal settings" "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=www.w3.org\" \
+           -e \"PROXY_SERVICE_HOST=http://www.w3.org\" \
            -e \"PROXY_SERVICE_PORT=80\""
 
 echo "Test it's up and working..."
 wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
 
+start_test "Start we auto add a protocol " "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=www.w3.org\" \
+           -e \"PROXY_SERVICE_PORT=80\""
+
+echo "Test It works if we do not define the protocol.."
+wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
 
 
 start_test "Start with multi locations settings" "${STD_CMD} \
            -e \"LOCATIONS_CSV=/,/news\" \
-           -e \"PROXY_SERVICE_HOST_1=www.w3.org\" \
+           -e \"PROXY_SERVICE_HOST_1=http://www.w3.org\" \
            -e \"PROXY_SERVICE_PORT_1=80\" \
-           -e \"PROXY_SERVICE_HOST_2=www.bbc.co.uk\" \
+           -e \"PROXY_SERVICE_HOST_2=http://www.bbc.co.uk\" \
            -e \"PROXY_SERVICE_PORT_2=80\""
+
 
 echo "Test for location 1 @ /..."
 wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
@@ -112,7 +119,7 @@ wget -O /dev/null --no-check-certificate --header="Host: www.bbc.co.uk" https://
 
 
 start_test "Start with Multiple locations, single proxy and NAXSI download." "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=www.bbc.co.uk\" \
+           -e \"PROXY_SERVICE_HOST=http://www.bbc.co.uk\" \
            -e \"PROXY_SERVICE_PORT=80\" \
            -e \"LOCATIONS_CSV=/,/news\" \
            -e \"NAXSI_RULES_URL_CSV_1=https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules\" \
@@ -131,7 +138,7 @@ cd ./client_certs/
 ./sign_client_key_with_ca.sh
 cd ..
 start_test "Start with Client CA, and single proxy. Block unauth for /standards" "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=www.w3.org\" \
+           -e \"PROXY_SERVICE_HOST=http://www.w3.org\" \
            -e \"PROXY_SERVICE_PORT=80\" \
            -e \"LOCATIONS_CSV=/,/standards/\" \
            -e \"CLIENT_CERT_REQUIRED_2=TRUE\" \
@@ -155,7 +162,7 @@ wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/sta
 
 
 start_test "Start with Custom error pages redirect off" "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"LOCATIONS_CSV=/,/api/\" \
            -e \"ERROR_REDIRECT_CODES_2=502\" \
@@ -173,7 +180,7 @@ else
 fi
 
 start_test "Start with Custom upload size" "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"CLIENT_MAX_BODY_SIZE=15\" \
            -e \"NAXSI_USE_DEFAULT_RULES=FALSE\" \
@@ -189,7 +196,7 @@ grep "Thanks for the big doc" /tmp/upload_test.txt &> /dev/null
 
 start_test "Start with listen for port 80" "${STD_CMD} \
            -p 8888:80 \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"DNSMASK=TRUE\" \
            -e \"ENABLE_UUID_PARAM=FALSE\" \
@@ -199,7 +206,7 @@ echo "Test Redirect ok..."
 wget -O /dev/null --no-check-certificate http://${DOCKER_HOST_NAME}:8888/
 
 start_test "Test text logging format..." "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"DNSMASK=TRUE\" \
            -e \"LOG_FORMAT_NAME=text\" \
@@ -211,7 +218,7 @@ echo "Testing text logs format..."
 ${SUDO_CMD} docker logs ${INSTANCE} | grep '127.0.0.1 - -'
 
 start_test "Test json logging format..." "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"DNSMASK=TRUE\" \
            -e \"LOG_FORMAT_NAME=json\" \
@@ -222,7 +229,7 @@ echo "Testing json logs format..."
 ${SUDO_CMD} docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 
 start_test "Test ENABLE_WEB_SOCKETS..." "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"DNSMASK=TRUE\" \
            -e \"ENABLE_WEB_SOCKETS=TRUE\" \
@@ -231,7 +238,7 @@ start_test "Test ENABLE_WEB_SOCKETS..." "${STD_CMD} \
 wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
 
 start_test "Test ADD_NGINX_LOCATION_CFG param..." "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=mockserver\" \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"LOCATIONS_CSV=/,/api/\" \
            -e \"ADD_NGINX_LOCATION_CFG=return 200 NICE;\" \

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -25,8 +25,13 @@ ERROR_REDIRECT_CODES=$(get_id_var ${LOCATION_ID} ERROR_REDIRECT_CODES)
 ENABLE_WEB_SOCKETS=$(get_id_var ${LOCATION_ID} ENABLE_WEB_SOCKETS)
 ADD_NGINX_LOCATION_CFG=$(get_id_var ${LOCATION_ID} ADD_NGINX_LOCATION_CFG)
 
+# Backwards compatability
+if [ "`echo ${PROXY_SERVICE_HOST} | grep -i 'https\?://'`" = "" ]; then
+  PROXY_SERVICE_HOST="http://${PROXY_SERVICE_HOST}"
+fi
+
 msg "Setting up location '${LOCATION}' to be proxied to " \
-    "http://${PROXY_SERVICE_HOST}:${PROXY_SERVICE_PORT}${LOCATION}"
+    "${PROXY_SERVICE_HOST}:${PROXY_SERVICE_PORT}${LOCATION}"
 
 eval PROXY_HOST=$(eval "echo $PROXY_SERVICE_HOST")
 export PROXY_SERVICE_PORT=$(eval "echo $PROXY_SERVICE_PORT")
@@ -40,8 +45,9 @@ if diff /container_default_ngx /tmp/nginx_new ; then
         echo "PROXY_SERVICE_PORT=$PROXY_SERVICE_PORT"
         exit 1
     fi
-    msg "Proxying to : http://$PROXY_SERVICE_HOST:$PROXY_SERVICE_PORT"
+    msg "Proxying to : $PROXY_SERVICE_HOST:$PROXY_SERVICE_PORT"
 fi
+
 
 if [ "${NAXSI_RULES_URL_CSV}" != "" ]; then
     if [ "${NAXSI_RULES_MD5_CSV}" == "" ]; then

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -26,7 +26,9 @@ ENABLE_WEB_SOCKETS=$(get_id_var ${LOCATION_ID} ENABLE_WEB_SOCKETS)
 ADD_NGINX_LOCATION_CFG=$(get_id_var ${LOCATION_ID} ADD_NGINX_LOCATION_CFG)
 
 # Backwards compatability
-if [ "`echo ${PROXY_SERVICE_HOST} | grep -i 'https\?://'`" = "" ]; then
+# This tests for the presence of :// which if missing means we do nt have 
+# a protocol so we default to http://
+if [ "`echo ${PROXY_SERVICE_HOST} | grep '://'`" = "" ]; then
   PROXY_SERVICE_HOST="http://${PROXY_SERVICE_HOST}"
 fi
 

--- a/location_template.conf
+++ b/location_template.conf
@@ -1,5 +1,5 @@
 
-    set $backend_upstream "http://$proxy_address";
+    set $backend_upstream "$proxy_address";
     proxy_pass $backend_upstream;
     proxy_redirect  off;
     proxy_intercept_errors on;


### PR DESCRIPTION
This changes the PROXY_SERVICE_HOST to include the protocol http or https
So that we can proxy https websites. Currently it is backwards compatible adding
http:// if https:// or http:// is not specified already present

While doing this commit I noted the change is not great as it assumes the protocol will be http of https. 