### PR TITLE
Hide the server vesion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/docker-centos-base:master
+FROM quay.io/ukhomeofficedigital/centos-base:master
 
 MAINTAINER Lewis Marshall <lewis@technoplusit.co.uk>
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -64,6 +64,8 @@ http {
 
         # Set the correct host name from the request header...
         server_name $host;
+        # Dont publish the version we are running
+        server_tokens off;
 
         set_by_lua_file $https_port_string lua/get_env.lua 'HTTPS_PORT_STRING';
         # Will redirect requests not on https


### PR DESCRIPTION
This came up in a pentest as a LOW its a simple fix so I thought I would add it 
now we get a server header of -
Server: openresty
before we got -
Server: openresty/1.7.10.1

Also fixed the dockerfile to the correct name. 