### PR TITLE
Enable gzip compression for lots of content types.

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -119,6 +119,14 @@ echo "Test ok..."
 wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
 unset HTTPS_LISTEN_PORT
 
+start_test "Test response has gzip" "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           --link mockserver:mockserver "
+echo "Test gzip ok..."
+curl -s -I -X GET -k --compressed https://${DOCKER_HOST_NAME}:${PORT} | grep -q 'Content-Encoding: gzip'
+
 start_test "Start with SSL CIPHER set and PROTOCOL" "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=www.w3.org\" \
            -e \"PROXY_SERVICE_PORT=80\" \
@@ -238,7 +246,6 @@ start_test "Start with listen for port 80" "${STD_CMD} \
            --link mockserver:mockserver "
 echo "Test Redirect ok..."
 wget -O /dev/null --no-check-certificate http://${DOCKER_HOST_NAME}:8888/
-
 
 
 start_test "Test text logging format..." "${STD_CMD} \

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,59 @@ http {
 
     lua_package_path 'conf/?.lua;;';
 
+    # Compression
+
+    # Enable Gzip compressed.
+    gzip on;
+
+    # Compression level (1-9).
+    # 5 is a perfect compromise between size and cpu usage, offering about
+    # 75% reduction for most ascii files (almost identical to level 9).
+    gzip_comp_level    5;
+
+    # Don't compress anything that's already small and unlikely to shrink much
+    # if at all (the default is 20 bytes, which is bad as that usually leads to
+    # larger files after gzipping).
+    gzip_min_length    256;
+
+    # Compress data even for clients that are connecting to us via proxies,
+    # identified by the "Via" header (required for CloudFront).
+    gzip_proxied       any;
+
+    # Tell proxies to cache both the gzipped and regular version of a resource
+    # whenever the client's Accept-Encoding capabilities header varies;
+    # Avoids the issue where a non-gzip capable client (which is extremely rare
+    # today) would display gibberish if their proxy gave them the gzipped version.
+    gzip_vary          on;
+
+    # Compress all output labeled with one of the following MIME-types.
+    gzip_types
+      application/atom+xml
+      application/javascript
+      application/json
+      application/ld+json
+      application/manifest+json
+      application/rss+xml
+      application/vnd.geo+json
+      application/vnd.ms-fontobject
+      application/x-font-ttf
+      application/x-web-app-manifest+json
+      application/xhtml+xml
+      application/xml
+      font/opentype
+      image/bmp
+      image/svg+xml
+      image/x-icon
+      text/cache-manifest
+      text/css
+      text/plain
+      text/vcard
+      text/vnd.rim.location.xloc
+      text/vtt
+      text/x-component
+      text/x-cross-domain-policy;
+    # text/html is always compressed by HttpGzipModule
+
     # Text format extended logging
     log_format extended_text '$real_client_ip_if_set$remote_addr - $remote_user [$time_local] '
                              '"$request"$uuid_log_opt $status $bytes_sent '


### PR DESCRIPTION
This is taken from:

https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf

It's quite mature and seems like quite a comprehensive list.