### PR TITLE
Looking at upgrading versions of openresty and luarocks. Noticed that…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ cd ..
 mkdir -p /usr/local/openresty/naxsi/
 cp ./naxsi-master/naxsi_config/naxsi_core.rules  /usr/local/openresty/naxsi/
 
-cd luarocks-2.2.1
+cd luarocks-${LUAROCKS_VER}
 ./configure --with-lua=/usr/local/openresty/luajit \
     --lua-suffix=jit-2.1.0-alpha \
     --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1


### PR DESCRIPTION
… LUAROCKS_VER variable in build.sh is not used throughout the script so fixed it.
Just one word difference.