### PR TITLE
UUID request ID logging in headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 
 script:
-  - ./ci-build.sh
+  - travis_retry ./ci-build.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ rules to be specified without downloading or mounting in a rule file.
 * `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file.
 * `ENABLE_UUID_PARAM` - If set to "FALSE", will NOT add a UUID url parameter to all requests. The Default will add this
  for easy tracking in down stream logs e.g. `nginxId=50c91049-667f-4286-c2f0-86b04b27d3f0`.
+ If set to `HEADER` it will add `nginxId` to the headers, not append to the get params.
 * `CLIENT_CERT_REQUIRED` - if set to `TRUE`, will deny access at this location, see [Client Certs](#client-certs).
 * `ERROR_REDIRECT_CODES` - Can override when Nginx will redirect requests to the error page. Defaults to 
 "`500 501 502 503 504`"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -13,7 +13,7 @@ function tear_down_container() {
         if docker ps | grep "${container}" &>/dev/null ; then
             docker kill "${container}" &>/dev/null
         fi
-        docker rm "${container}"
+        docker rm "${container}" &>/dev/null
     fi
 }
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -6,8 +6,7 @@ TAG=ngx
 COUNT=0
 PORT=8443
 START_INSTANCE="docker run --privileged=true "
-
-source ./helper.sh
+DOCKER_HOST_NAME=127.0.0.1
 
 function tear_down_container() {
     container=$1
@@ -28,10 +27,6 @@ function clean_up() {
     tear_down_container mockserver
 }
 
-function wait_until_started() {
-    docker exec -it ${INSTANCE} /readyness.sh POLL
-}
-
 function start_test() {
     COUNT=$((COUNT + 1))
     PORT=$((PORT + 1))
@@ -47,11 +42,7 @@ function start_test() {
     shift
     echo "Running:$@ --name ${INSTANCE} -p ${PORT}:${HTTPS_LISTEN_PORT} ${TAG}"
     bash -c "$@ --name ${INSTANCE} -d -p ${PORT}:${HTTPS_LISTEN_PORT} ${TAG}"
-    if ! wait_until_started ; then
-        echo "Error, not started in time..."
-        docker logs ${INSTANCE}
-        exit 1
-    fi
+    docker run --rm --link ${INSTANCE}:${INSTANCE} martin/wait
 }
 
 clean_up

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -76,8 +76,8 @@ echo "Test limited protcol and SSL cipher... "
 docker run --link ${TAG}:${TAG}--rm --entrypoint bash ngx -c "echo GET / | /usr/bin/openssl s_client -cipher 'AES256+EECDH' -tls1_2 -connect ${TAG}:443" &> /dev/null;
 echo "Test sslv2 not accepted...."
 if docker run --link ${TAG}:${TAG}--rm --entrypoint bash ngx -c "echo GET / | /usr/bin/openssl s_client -ssl2 -connect ${TAG}:443" &> /dev/null; then
-  echo "FAIL SSL defaults settings allow ssl2 ......" 
-  exit 2 
+  echo "FAIL SSL defaults settings allow ssl2 ......"
+  exit 2
 fi
 
 start_test "Test enabling GEODB settings" "${STD_CMD} \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -154,19 +154,6 @@ else
     exit 1
 fi
 
-
-HTTPS_LISTEN_PORT=$((PORT + 1))
-start_test "Start with listen for HTTPS port 4430" "${STD_CMD} \
-           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
-           -e \"PROXY_SERVICE_PORT=8080\" \
-           -e \"DNSMASK=TRUE\" \
-           -e \"ENABLE_UUID_PARAM=FALSE\" \
-           -e \"HTTPS_LISTEN_PORT=${HTTPS_LISTEN_PORT}\" \
-           --link mockserver:mockserver "
-echo "Test ok..."
-wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
-unset HTTPS_LISTEN_PORT
-
 start_test "Test response has gzip" "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -73,9 +73,9 @@ start_test "Start with minimal settings" "${STD_CMD} \
 echo "Test it's up and working..."
 wget -O /dev/null --no-check-certificate https://${DOCKER_HOST_NAME}:${PORT}/
 echo "Test limited protcol and SSL cipher... "
-echo "GET /" | openssl s_client -cipher 'AES256+EECDH' -tls1_2 -connect ${DOCKER_HOST_NAME}:${PORT} &> /dev/null
-echo "Test sslv2 not excepted...."
-if echo "GET /" | openssl s_client -ssl2 -connect ${DOCKER_HOST_NAME}:${PORT} &> /dev/null ; then
+docker run --link ${TAG}:${TAG}--rm --entrypoint bash ngx -c "echo GET / | /usr/bin/openssl s_client -cipher 'AES256+EECDH' -tls1_2 -connect ${TAG}:443" &> /dev/null;
+echo "Test sslv2 not accepted...."
+if docker run --link ${TAG}:${TAG}--rm --entrypoint bash ngx -c "echo GET / | /usr/bin/openssl s_client -ssl2 -connect ${TAG}:443" &> /dev/null; then
   echo "FAIL SSL defaults settings allow ssl2 ......" 
   exit 2 
 fi
@@ -164,7 +164,9 @@ start_test "Start with SSL CIPHER set and PROTOCOL" "${STD_CMD} \
            -e \"SSL_CIPHERS=RC4-MD5\" \
            -e \"SSL_PROTOCOLS=TLSv1.1\""
 echo "Test excepts defined protocol and cipher....."
-echo "GET /" | openssl s_client -cipher 'RC4-MD5' -tls1_1 -connect ${DOCKER_HOST_NAME}:${PORT}
+docker run --link ${TAG}:${TAG}--rm --entrypoint bash ngx -c "echo GET / | /usr/bin/openssl s_client -cipher 'RC4-MD5' -tls1_1 -connect ${TAG}:443" &> /dev/null;
+
+
 
 start_test "Start we auto add a protocol " "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=www.w3.org\" \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -52,7 +52,9 @@ STD_CMD="${START_INSTANCE}"
 echo "========"
 echo "BUILD..."
 echo "========"
+echo "travis_fold:start:BUILD"
 docker build -t ${TAG} .
+echo "travis_fold:end:BUILD"
 
 echo "Running mocking-server..."
 ${STD_CMD} -d -p 8080:8080 \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -3,7 +3,6 @@
 set -e
 
 TAG=ngx
-COUNT=0
 PORT=8443
 START_INSTANCE="docker run --privileged=true "
 DOCKER_HOST_NAME=127.0.0.1
@@ -28,12 +27,9 @@ function clean_up() {
 }
 
 function start_test() {
-    COUNT=$((COUNT + 1))
-    PORT=$((PORT + 1))
-    INSTANCE=${TAG}_$COUNT
-    HTTPS_LISTEN_PORT=${HTTPS_LISTEN_PORT:-443}
-
+    INSTANCE=${TAG}
     tear_down
+    HTTPS_LISTEN_PORT=${HTTPS_LISTEN_PORT:-443}
     echo ""
     echo ""
     echo "_____________"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -11,13 +11,11 @@ source ./helper.sh
 
 function tear_down_container() {
     container=$1
-    if [ "${TEAR_DOWN}" == "true" ]; then
-        if docker ps -a | grep "${container}" &>/dev/null ; then
-            if docker ps | grep "${container}" &>/dev/null ; then
-                ${SUDO_CMD} docker stop "${container}"
-            fi
-            ${SUDO_CMD} docker rm "${container}"
+    if docker ps -a | grep "${container}" &>/dev/null ; then
+        if docker ps | grep "${container}" &>/dev/null ; then
+            ${SUDO_CMD} docker stop "${container}"
         fi
+        ${SUDO_CMD} docker rm "${container}"
     fi
 }
 
@@ -56,18 +54,9 @@ function start_test() {
     fi
 }
 
-# Cope with local builds with docker machine...
-if [ "${DOCKER_MACHINE_NAME}" == "" ]; then
-    DOCKER_HOST_NAME=localhost
-    SUDO_CMD=sudo
-    # On travis... need to do this for it to work!
-    ${SUDO_CMD} service docker restart ; sleep 10
-else
-    DOCKER_HOST_NAME=$(docker-machine ip ${DOCKER_MACHINE_NAME})
-    TEAR_DOWN=true
-    SUDO_CMD=""
-    clean_up
-fi
+SUDO_CMD=""
+clean_up
+
 STD_CMD="${SUDO_CMD} ${START_INSTANCE}"
 
 echo "========"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -275,7 +275,7 @@ start_test "Start with listen for port 80" "${STD_CMD} \
            -e \"PROXY_SERVICE_PORT=8080\" \
            -e \"DNSMASK=TRUE\" \
            -e \"ENABLE_UUID_PARAM=FALSE\" \
-           -e \"HTTPS_REDIRECT_PORT=$((PORT + 1))\" \
+           -e \"HTTPS_REDIRECT_PORT=${PORT}\" \
            --link mockserver:mockserver "
 echo "Test Redirect ok..."
 wget -O /dev/null --no-check-certificate http://${DOCKER_HOST_NAME}:8888/

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -130,7 +130,7 @@ elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
     msg "Auto UUID request header enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}
 else
-    UUID_ARGS='set $args $args&nginxId=$uuidopt;'
+    UUID_ARGS='if ($is_args) {set $args $args&nginxId=$uuidopt;} if ($is_args = "") { set $args nginxId=$uuidopt;}'
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -124,8 +124,13 @@ fi
 if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
     UUID_ARGS=''
     msg "Auto UUID request parameter disabled for location ${LOCATION_ID}."
+elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
+    UUID_ARGS='proxy_set_header nginxId $uuidopt;'
+    # Ensure nginx enables this globaly
+    msg "Auto UUID request header enabled for location ${LOCATION_ID}."
+    touch ${UUID_FILE}
 else
-    UUID_ARGS='set $args $args$uuidopt;'
+    UUID_ARGS='set $args $args&nginxId=$uuidopt;'
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -7,6 +7,5 @@ else
     local uuid_str = uuid()
     ngx.var.uuid = uuid_str
     ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
-    local uuid_opt = "&nginxId=" .. uuid_str
-    return uuid_opt
+    return uuid_str
 end

--- a/monkey-business.yaml
+++ b/monkey-business.yaml
@@ -1,0 +1,2 @@
+- delay: 3000
+  frequency: 1

--- a/test-servers.yaml
+++ b/test-servers.yaml
@@ -13,6 +13,22 @@
    response:
      code: 200
      body: '200 is OK :)'
+ - name: All OK with nginxID
+   request:
+     uri: /?nginxId=foo
+     regexuri: \/?nginxId=[a-z]+
+     method: GET
+   response:
+     code: 200
+     body: '200 is OK :)'
+ - name: All OK with nginxID and other get params
+   request:
+     uri: /?foo=bar&nginxId=foo
+     regexuri: \/?foo=bar&nginxId=[a-z]+
+     method: GET
+   response:
+     code: 200
+     body: '200 is OK :)'
  - name: Big Doc
    request:
      uri: /uploads/doc

--- a/test-servers.yaml
+++ b/test-servers.yaml
@@ -55,10 +55,3 @@
      body: '{"message": "Oh dear!"}'
      headers:
        content-type: text/json
- - name: Long Req
-   request:
-     uri: /three-seconds
-     method: GET
-   response:
-     code: 200
-     body: "SLOW"


### PR DESCRIPTION
* allow for UUID to be set in the http headers rather than in GET params
* when UUID is in GET params form a valid url
* fix what is presumably a typo in the config
* test fixtures and tests for UUID stuff
* update mocking-jay server
* enable debug output from mockserver
* wait for mockingserver to be up with `martin/wait` rather than rely on 5 seconds being enough