### PR TITLE
Bugfix: Proxy protocol doesn't mix with NAXSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ This is useful when testing or for development instances or when a load-balancer
 * `SERVER_KEY` - Can override where to find the server's SSL key.
 * `SSL_CIPHERS` - Change the SSL ciphers support default only AES256+EECDH:AES256+EDH:!aNULL
 * `SSL_PROTOCOLS` - Change the SSL protocols supported default only TLSv1.2
-* `HTTP_LISTEN_PORT` - Change the default inside the container from 80. Note: Port 10418 is reserved for internal processing.
-* `HTTPS_LISTEN_PORT` - Change the default inside the container from 443. Note: Port 10418 is reserved for internal processing.
+* `HTTP_LISTEN_PORT` - Change the default inside the container from 80.
+* `HTTPS_LISTEN_PORT` - Change the default inside the container from 443.
+* `INTERNAL_LISTEN_PORT` - Change the default inside the container from 10418. Note: This is used for internal processing and is not available externally.
 * `HTTPS_REDIRECT` - Toggle whether or not we force redirects to HTTPS.  Defaults to true.
 * `ALLOW_COUNTRY_CSV` - List of [country codes](http://dev.maxmind.com/geoip/legacy/codes/iso3166/) to allow.
 * `STATSD_METRICS_ENABLED` - Toggle if metrics are logged to statsd (defaults to true)

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ This is useful when testing or for development instances or when a load-balancer
 * `SERVER_KEY` - Can override where to find the server's SSL key.
 * `SSL_CIPHERS` - Change the SSL ciphers support default only AES256+EECDH:AES256+EDH:!aNULL
 * `SSL_PROTOCOLS` - Change the SSL protocols supported default only TLSv1.2
-* `HTTP_LISTEN_PORT` - Change the default inside the container from 80.
-* `HTTPS_LISTEN_PORT` - Change the default inside the container from 443. 
+* `HTTP_LISTEN_PORT` - Change the default inside the container from 80. Note: Port 10418 is reserved for internal processing.
+* `HTTPS_LISTEN_PORT` - Change the default inside the container from 443. Note: Port 10418 is reserved for internal processing.
 * `HTTPS_REDIRECT` - Toggle whether or not we force redirects to HTTPS.  Defaults to true.
 * `ALLOW_COUNTRY_CSV` - List of [country codes](http://dev.maxmind.com/geoip/legacy/codes/iso3166/) to allow.
 * `STATSD_METRICS_ENABLED` - Toggle if metrics are logged to statsd (defaults to true)

--- a/go.sh
+++ b/go.sh
@@ -26,14 +26,14 @@ if [ "${LOCATIONS_CSV}" == "" ]; then
     LOCATIONS_CSV=/
 fi
 
-NAXSI_LISTEN_PORT="10418"
+INTERNAL_LISTEN_PORT="${INTERNAL_LISTEN_PORT:-10418}"
 NGIX_LISTEN_CONF="${NGIX_CONF_DIR}/nginx_listen.conf"
 
 cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 		set \$http_listen_port '${HTTP_LISTEN_PORT}';
 		set \$https_listen_port '${HTTPS_LISTEN_PORT}';
-		set \$naxsi_listen_port '${NAXSI_LISTEN_PORT}';
-		listen localhost:${NAXSI_LISTEN_PORT} ssl;
+		set \$internal_listen_port '${INTERNAL_LISTEN_PORT}';
+		listen localhost:${INTERNAL_LISTEN_PORT} ssl;
 EOF-LISTEN
 
 if [ "${LOAD_BALANCER_CIDR}" != "" ]; then

--- a/go.sh
+++ b/go.sh
@@ -26,29 +26,35 @@ if [ "${LOCATIONS_CSV}" == "" ]; then
     LOCATIONS_CSV=/
 fi
 
+NAXSI_LISTEN_PORT="10418"
+NGIX_LISTEN_CONF="${NGIX_CONF_DIR}/nginx_listen.conf"
+
+cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
+		set \$http_listen_port '${HTTP_LISTEN_PORT}';
+		set \$https_listen_port '${HTTPS_LISTEN_PORT}';
+		set \$naxsi_listen_port '${NAXSI_LISTEN_PORT}';
+		listen localhost:${NAXSI_LISTEN_PORT} ssl;
+EOF-LISTEN
+
 if [ "${LOAD_BALANCER_CIDR}" != "" ]; then
     msg "Using proxy_protocol from '$LOAD_BALANCER_CIDR' (real client ip is forwarded correctly by loadbalancer)..."
     export REMOTE_IP_VAR="proxy_protocol_addr"
-    cat > ${NGIX_CONF_DIR}/nginx_listen.conf <<-EOF-LISTEN-PP
+    cat >> ${NGIX_LISTEN_CONF} <<-EOF-LISTEN-PP
 		listen ${HTTP_LISTEN_PORT} proxy_protocol;
 		listen ${HTTPS_LISTEN_PORT} proxy_protocol ssl;
 		real_ip_recursive on;
 		real_ip_header proxy_protocol;
 		set \$real_client_ip_if_set '\$proxy_protocol_addr ';
 		set_real_ip_from ${LOAD_BALANCER_CIDR};
-		set \$http_listen_port '${HTTP_LISTEN_PORT}';
-		set \$https_listen_port '${HTTPS_LISTEN_PORT}';
 	EOF-LISTEN-PP
 else
     msg "No \$LOAD_BALANCER_CIDR set, using straight SSL (client ip will be from loadbalancer if used)..."
     export REMOTE_IP_VAR="remote_addr"
-    cat > ${NGIX_CONF_DIR}/nginx_listen.conf <<-EOF-LISTEN
-		listen ${HTTP_LISTEN_PORT} ;
+    cat >> ${NGIX_LISTEN_CONF} <<-EOF-LISTEN-NONPP
+		listen ${HTTP_LISTEN_PORT};
 		listen ${HTTPS_LISTEN_PORT} ssl;
 		set \$real_client_ip_if_set '';
-		set \$http_listen_port '${HTTP_LISTEN_PORT}';
-		set \$https_listen_port '${HTTPS_LISTEN_PORT}';
-	EOF-LISTEN
+	EOF-LISTEN-NONPP
 fi
 
 IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"

--- a/nginx.conf
+++ b/nginx.conf
@@ -132,7 +132,7 @@ http {
 
         location /RequestDenied {
             # Proxy to ourselves in order to access NAXSI debugging headers
-            proxy_pass https://127.0.0.1:$naxsi_listen_port/nginx-proxy/RequestDenied;
+            proxy_pass https://127.0.0.1:$internal_listen_port/nginx-proxy/RequestDenied;
             internal;
         }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -132,7 +132,7 @@ http {
 
         location /RequestDenied {
             # Proxy to ourselves in order to access NAXSI debugging headers
-            proxy_pass https://127.0.0.1:$https_listen_port/nginx-proxy/RequestDenied;
+            proxy_pass https://127.0.0.1:$naxsi_listen_port/nginx-proxy/RequestDenied;
             internal;
         }
 


### PR DESCRIPTION
Fixes a bug in which requests blocked by NAXSI came back as a 502 rather
than a 418 when running with proxy protocol enabled. This is because the
/RequestDenied route proxies to localhost but doesn't know to speak
proxy protocol.

This has been fixed by giving NAXSI its own private port of 10418 that
never expects proxy protocol.