### PR TITLE
Add headers for more security

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -79,6 +79,25 @@ http {
     include /usr/local/openresty/nginx/conf/upload_size*.conf;
     include /usr/local/openresty/nginx/conf/nginx_http_extras*.conf;
 
+    # config to not allow the browser to render the page inside an frame or iframe
+    # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+    add_header X-Frame-Options SAMEORIGIN;
+
+    # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
+    # to disable content-type sniffing on some browsers.
+    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    add_header X-Content-Type-Options nosniff;
+
+    # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
+    # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
+    # this particular website if it was disabled by the user.
+    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    add_header X-XSS-Protection "1; mode=block";
+
+    # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+    # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
   # Accept underscores in headers as NAXSI does this
   underscores_in_headers on;
 
@@ -86,13 +105,13 @@ http {
     include /usr/local/openresty/nginx/conf/nginx_statsd_metrics.conf;
     include /usr/local/openresty/nginx/conf/response_body.conf;
         # Optionally listen to proxy protocol:
-        include  /usr/local/openresty/nginx/conf/nginx_listen.conf ;
+        include  /usr/local/openresty/nginx/conf/nginx_listen.conf;
 
         # These should be volume added:
         include /usr/local/openresty/nginx/conf/server_certs.conf;
 
         # Optionally include client cert config:
-        include /usr/local/openresty/nginx/conf/client_certs*.conf ;
+        include /usr/local/openresty/nginx/conf/client_certs*.conf;
 
         # Set the correct host name from the request header...
         server_name $host;
@@ -101,7 +120,7 @@ http {
 
         set_by_lua_file $https_port_string lua/get_env.lua 'HTTPS_REDIRECT_PORT_STRING';
         # Will redirect requests not on https if HTTPS_REDIRECT=TRUE (the default)
-        include /usr/local/openresty/nginx/conf/ssl_redirect.conf ; 
+        include /usr/local/openresty/nginx/conf/ssl_redirect.conf ;
 
         include /usr/local/openresty/nginx/conf/nginx_server_extras*.conf ;
 
@@ -147,7 +166,7 @@ http {
         access_log   off;
         allow 127.0.0.1;
         deny all;
-      }   
+      }
    }
 }
 events {


### PR DESCRIPTION
- X-Frame-Options so browser cannot render page in a frame
- X-Content-Tyoe-Options to disable content type sniffing
- X-XSS-Protection to ensure the cross-site scripting browser filter is enabled
- Strict-Transport-Security to instruct the browser to only access a web
application over a secure connection and and remember it for 12 months
- Cache-control to stop the browser of intermediary from caching sensitive data