### PR TITLE
Add major and minor version tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,16 +15,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://127.0.0.1:2375
     commands:
-      - REPO="artifactory-internal.digital.homeoffice.gov.uk"
-      - BASE="/"
-      - NAME="nginx-proxy"
-      - FULL_NAME="${REPO}${BASE}${NAME}"
-      - DOCKER_USERNAME="lev-web-robot"
-      - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" "${REPO}"
-      - docker tag ngx "${FULL_NAME}:${DRONE_TAG}"
-      - docker tag ngx "${FULL_NAME}:latest"
-      - docker push "${FULL_NAME}:${DRONE_TAG}"
-      - docker push "${FULL_NAME}:latest"
+      - ./publish.sh
     when:
       event: tag
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+REPO="artifactory-internal.digital.homeoffice.gov.uk"
+BASE="/"
+NAME="nginx-proxy"
+FULL_NAME="${REPO}${BASE}${NAME}"
+DOCKER_USERNAME="lev-web-robot"
+docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" "${REPO}"
+docker tag ngx "${FULL_NAME}:${DRONE_TAG}"
+docker tag ngx "${FULL_NAME}:latest"
+docker push "${FULL_NAME}:${DRONE_TAG}"
+docker push "${FULL_NAME}:latest"

--- a/publish.sh
+++ b/publish.sh
@@ -5,8 +5,15 @@ BASE="/"
 NAME="nginx-proxy"
 FULL_NAME="${REPO}${BASE}${NAME}"
 DOCKER_USERNAME="lev-web-robot"
+
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" "${REPO}"
-docker tag ngx "${FULL_NAME}:${DRONE_TAG}"
-docker tag ngx "${FULL_NAME}:latest"
-docker push "${FULL_NAME}:${DRONE_TAG}"
-docker push "${FULL_NAME}:latest"
+
+tag_n_push() {
+  echo "Publishing ${1} of ${NAME}..."
+  docker tag ngx "${FULL_NAME}:${1}"
+  docker push "${FULL_NAME}:${1}"
+  echo "published ${1}"
+}
+
+tag_n_push "${DRONE_TAG}"
+tag_n_push "latest"

--- a/publish.sh
+++ b/publish.sh
@@ -6,6 +6,10 @@ NAME="nginx-proxy"
 FULL_NAME="${REPO}${BASE}${NAME}"
 DOCKER_USERNAME="lev-web-robot"
 
+PATCH="${DRONE_TAG}"
+MINOR=`echo ${PATCH} | awk -F '.' '{print $1"."$2}'`
+MAJOR=`echo ${MINOR} | awk -F '.' '{print $1}'`
+
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" "${REPO}"
 
 tag_n_push() {
@@ -15,5 +19,7 @@ tag_n_push() {
   echo "published ${1}"
 }
 
-tag_n_push "${DRONE_TAG}"
+tag_n_push "${PATCH}"
+tag_n_push "${MINOR}"
+tag_n_push "${MAJOR}"
 tag_n_push "latest"


### PR DESCRIPTION
Currently `nginx-proxy` images are only tagged with the full version and `latest`. The proposed changes add tags for part versions containing; the major version number only, and the major and minor version numbers only.

E.G.
A new version of `ngins-proxy` is tagged as `v3.2.8`, the following image tags would be created and pushed:
 - `v3.2.8`
 - `v3.2`
 - `v3`
 - `latest`

The tagging and pushing operations have been extracted out of the `.drone.yml` file and into a separate `publish.sh` script for greater clarity.