### PR TITLE
Allow users to disable the Sysdig metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This is useful when testing or for development instances or when a load-balancer
 * `ALLOW_COUNTRY_CSV` - List of [country codes](http://dev.maxmind.com/geoip/legacy/codes/iso3166/) to allow.
 * `STATSD_METRICS_ENABLED` - Toggle if metrics are logged to statsd (defaults to true)
 * `STATSD_SERVER` - Server to send statsd metrics to, defaults to 127.0.0.1
+* `DISABLE_SYSDIG_METRICS` - Set to any non-empty string to disable support for Sysdig's metric collection
 
 ### Ports
 

--- a/go.sh
+++ b/go.sh
@@ -57,6 +57,22 @@ else
 	EOF-LISTEN-NONPP
 fi
 
+NGIX_SYSDIG_SERVER_CONF="${NGIX_CONF_DIR}/nginx_sysdig_server.conf"
+touch ${NGIX_SYSDIG_SERVER_CONF}
+if [ ! -z "${DISABLE_SYSDIG_METRICS}" ]; then
+    cat > ${NGIX_SYSDIG_SERVER_CONF} <<-EOF-SYSDIG-SERVER
+    server {
+      listen 10088;
+      location /nginx_status {
+        stub_status on;
+        access_log   off;
+        allow 127.0.0.1;
+        deny all;
+      }
+    }
+EOF-SYSDIG-SERVER
+fi
+
 IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
 for i in "${!LOCATIONS_ARRAY[@]}"; do
     /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}

--- a/nginx.conf
+++ b/nginx.conf
@@ -159,15 +159,8 @@ http {
 
         include /usr/local/openresty/nginx/conf/locations/*.conf ;
     }
-    server {
-      listen 10088;
-      location /nginx_status {
-        stub_status on;
-        access_log   off;
-        allow 127.0.0.1;
-        deny all;
-      }
-   }
+
+    include /usr/local/openresty/nginx/conf/nginx_sysdig_server.conf ;
 }
 events {
 }


### PR DESCRIPTION
This is useful for people who wish to run more than one proxy in the
same pod.