### PR TITLE
Remove extraneous 'cd -' before attempting to remove source trees

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,6 @@ cd ..
 luarocks install uuid
 luarocks install luasocket
 luarocks install lua-geoip
-cd -
 
 # Cleaning up source...
 rm -fr "openresty-${OPEN_RESTY_VER}"


### PR DESCRIPTION
Remove extraneous 'cd -' which prevented compiled source code
being removed.

'cd -' undid the effect of the previous 'cd', which was 'cd ..'
which undid the effect of the previous 'cd "luarocks-${LUAROCKS_VER}"'

The end result is that the rm commands to remove source trees after
compilation executed from within the luarocks source tree, removing
nothing.

Run the 'rm -rf's from the correct place and shrink the image by
around 20%