### PR TITLE
Misc cleanups, support for Amazon S3, custom log formats and custom UUID variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ managed by Docker or Kubernetes.
 * `CLIENT_MAX_BODY_SIZE` - Can set a larger upload than Nginx defaults in MB.
 * `HTTPS_REDIRECT_PORT` - Only required for http to https redirect and only when a non-standard https port is in use.
 This is useful when testing or for development instances or when a load-balancer mandates a non-standard port.
-* `LOG_FORMAT_NAME` - Can be set to `text` or `json` (default).
+* `LOG_FORMAT_NAME` - Can be set to `text`, `json` (default) or `custom`.
 * `NO_LOGGING_URL_PARAMS` - Can be set to `TRUE` if you don't want to log url params. Default is empty which means URL params are logged
 * `NO_LOGGING_BODY` - Defaults to true `TRUE`.  Set otherwise and nginx should log the request_body.
 * `NO_LOGGING_RESPONSE` - Defaults to true `TRUE`.  Set otherwise and nginx should log the response_body
+* `CUSTOM_LOG_FORMAT` - When `LOG_FORMAT_NAME` is set to `custom`, the log format to use
 * `SERVER_CERT` - Can override where to find the server's SSL cert.
 * `SERVER_KEY` - Can override where to find the server's SSL key.
 * `SSL_CIPHERS` - Change the SSL ciphers support default only AES256+EECDH:AES256+EDH:!aNULL

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Note the following variables can only be set once:
 [Arbitrary Config](#arbitrary-config)
 * `ADD_NGINX_HTTP_CFG` - Arbitrary extra NGINX configuration to be added to the http context, see
 [Arbitrary Config](#arbitrary-config)
+* `AWS_REGION` - Sets the AWS region this container is running in. Used to construct urls from which to download resources from. Defaults to 'eu-west-1' if not set.
+* `DOWNLOAD_VIA_S3_VPC_ENDPOINT` - Set to `TRUE` to download rules from S3. Default is `FALSE`.
 * `LOCATIONS_CSV` - Set to a list of locations that are to be independently proxied, see the example
 [Using Multiple Locations](#using-multiple-locations). Note, if this isn't set, `/` will be used as the default
 location.

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -454,6 +454,18 @@ echo "Testing json logs format..."
 docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 docker logs ${INSTANCE}  | grep 'animal=cow'
 
+start_test "Test custom logging format..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
+           -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"LOG_FORMAT_NAME=custom\" \
+           -e \"CUSTOM_LOG_FORMAT=' \\\$host:\\\$server_port \\\$uuid \\\$http_x_forwarded_for \\\$remote_addr \\\$remote_user [\\\$time_local] \\\$request \\\$status \\\$body_bytes_sent \\\$request_time \\\$http_x_forwarded_proto \\\$http_referer \\\$http_user_agent '\" \
+           -e \"ENABLE_UUID_PARAM=FALSE\" \
+           --link \"${MOCKSERVER}:${MOCKSERVER}\" "
+wget -O /dev/null --quiet --no-check-certificate --header="Host: example.com" https://${DOCKER_HOST_NAME}:${PORT}?animal=cow
+echo "Testing custom logs format..."
+docker logs ${INSTANCE} | egrep '^\{\sexample\.com:10443.*\[.*\]\sGET\s\/\?animal\=cow\sHTTP/[0-9]\.[0-9]\s200.*\s\}$'
+
 start_test "Test param logging off option works..." "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
            -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -454,7 +454,6 @@ echo "Testing json logs format..."
 docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 docker logs ${INSTANCE}  | grep 'animal=cow'
 
-
 start_test "Test param logging off option works..." "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
            -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \
@@ -548,6 +547,28 @@ if curl -k https://${DOCKER_HOST_NAME}:${PORT}/\?\"==\` | grep "Sorry, we are re
 else
   echo "Testing VERBOSE_ERROR_PAGES works..."
 fi
+
+start_test "Test setting UUID name works..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=custom_uuid_name\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "custom_uuid_name"
+echo "Testing setting UUID_VAR_NAME works"
+
+start_test "Test setting empty UUID name defaults correctly..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "nginxId"
+echo "Testing UUID_VAR_NAME default if empty works"
 
 echo "_________________________________"
 echo "We got here, ALL tests successful"

--- a/defaults.sh
+++ b/defaults.sh
@@ -2,6 +2,7 @@
 export NGIX_CONF_DIR=/usr/local/openresty/nginx/conf
 export NGINX_BIN=/usr/local/openresty/nginx/sbin/nginx
 export UUID_FILE=/tmp/uuid_on
+export UUID_VAR_NAME=${UUID_VAR_NAME:-'nginxId'}
 export DEFAULT_ERROR_CODES="500 501 502 503 504"
 export LOG_FORMAT_NAME=${LOG_FORMAT_NAME:-json}
 export SERVER_CERT=${SERVER_CERT:-/etc/keys/crt}

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export DOWNLOAD_VIA_S3_VPC_ENDPOINT=${DOWNLOAD_VIA_S3_VPC_ENDPOINT:-FALSE}
 export NGIX_CONF_DIR=/usr/local/openresty/nginx/conf
 export NGINX_BIN=/usr/local/openresty/nginx/sbin/nginx
 export UUID_FILE=/tmp/uuid_on
@@ -16,6 +17,7 @@ export NO_LOGGING_BODY=${NO_LOGGING_BODY:-'TRUE'}
 export NO_LOGGING_RESPONSE=${NO_LOGGING_RESPONSE:-'TRUE'}
 export STATSD_METRICS_ENABLED=${STATSD_METRICS:-'TRUE'}
 export STATSD_SERVER=${STATSD_SERVER:-'127.0.0.1'}
+export AWS_REGION=${AWS_REGION:-eu-west-1}
 
 export HTTPS_REDIRECT_PORT_STRING=":${HTTPS_REDIRECT_PORT}"
 if [ "${HTTPS_REDIRECT_PORT_STRING}" == ":" ]; then
@@ -40,7 +42,10 @@ function download() {
             msg "About to retry download for ${file_url}..."
             sleep 1
         fi
-        if curl --max-time 30 --fail -s -o ${file_path} ${file_url} ; then
+        if [ "$DOWNLOAD_VIA_S3_VPC_ENDPOINT" == TRUE ]; then
+            aws s3 cp --region "$AWS_REGION" --endpoint-url https://s3-"$AWS_REGION".amazonaws.com "$NAXSI_RULES_URL_CSV" "$file_path"
+            error=$?
+        elif curl --max-time 30 --fail -s -o ${file_path} ${file_url} ; then
             error=0
         fi
         if [ -n ${file_md5} ]; then

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -147,12 +147,12 @@ if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
     UUID_ARGS=''
     msg "Auto UUID request parameter disabled for location ${LOCATION_ID}."
 elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
-    UUID_ARGS='proxy_set_header nginxId $uuidopt;'
+    UUID_ARGS="proxy_set_header ${UUID_VAR_NAME} \$uuidopt;"
     # Ensure nginx enables this globaly
     msg "Auto UUID request header enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}
 else
-    UUID_ARGS='if ($is_args) {set $args $args&nginxId=$uuidopt;} if ($is_args = "") { set $args nginxId=$uuidopt;}'
+    UUID_ARGS="if (\$is_args) {set \$args \$args&${UUID_VAR_NAME}=\$uuidopt;} if (\$is_args = \"\") { set \$args ${UUID_VAR_NAME}=\$uuidopt;}"
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/go.sh
+++ b/go.sh
@@ -21,10 +21,7 @@ cat > ${NGIX_CONF_DIR}/server_certs.conf <<-EOF_CERT_CONF
     ssl_dhparam ${NGIX_CONF_DIR}/dhparam.pem;
 EOF_CERT_CONF
 
-
-if [ "${LOCATIONS_CSV}" == "" ]; then
-    LOCATIONS_CSV=/
-fi
+: "${LOCATIONS_CSV:=/}"
 
 INTERNAL_LISTEN_PORT="${INTERNAL_LISTEN_PORT:-10418}"
 NGIX_LISTEN_CONF="${NGIX_CONF_DIR}/nginx_listen.conf"
@@ -36,7 +33,7 @@ cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 		listen localhost:${INTERNAL_LISTEN_PORT} ssl;
 EOF-LISTEN
 
-if [ "${LOAD_BALANCER_CIDR}" != "" ]; then
+if [ -n "${LOAD_BALANCER_CIDR:-}" ]; then
     msg "Using proxy_protocol from '$LOAD_BALANCER_CIDR' (real client ip is forwarded correctly by loadbalancer)..."
     export REMOTE_IP_VAR="proxy_protocol_addr"
     cat >> ${NGIX_LISTEN_CONF} <<-EOF-LISTEN-PP
@@ -59,7 +56,7 @@ fi
 
 NGIX_SYSDIG_SERVER_CONF="${NGIX_CONF_DIR}/nginx_sysdig_server.conf"
 touch ${NGIX_SYSDIG_SERVER_CONF}
-if [ -z ${DISABLE_SYSDIG_METRICS+x} ]; then
+if [ -n "${DISABLE_SYSDIG_METRICS:-}" ]; then
     cat > ${NGIX_SYSDIG_SERVER_CONF} <<-EOF-SYSDIG-SERVER
     server {
       listen 10088;
@@ -78,7 +75,7 @@ for i in "${!LOCATIONS_ARRAY[@]}"; do
     /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}
 done
 
-if [ "${NAME_RESOLVER}" == "" ]; then
+if [ -z "${NAME_RESOLVER:-}" ]; then
     if [ "${DNSMASK}" == "TRUE" ]; then
         dnsmasq -p 5462
         export NAME_RESOLVER=127.0.0.1:5462
@@ -105,7 +102,7 @@ echo "HTTPS_LISTEN_PORT=${HTTPS_LISTEN_PORT}">/tmp/readyness.cfg
 if [ -f ${UUID_FILE} ]; then
     export LOG_UUID=TRUE
 fi
-if [ "${CLIENT_MAX_BODY_SIZE}" != "" ]; then
+if [ -n "${CLIENT_MAX_BODY_SIZE:-}" ]; then
     UPLOAD_SETTING="client_max_body_size ${CLIENT_MAX_BODY_SIZE}m;"
     echo "${UPLOAD_SETTING}">${NGIX_CONF_DIR}/upload_size.conf
     msg "Setting '${UPLOAD_SETTING};'"
@@ -122,18 +119,18 @@ else
 fi
 
 case "${LOG_FORMAT_NAME}" in
-    "json" | "text")
+    json|text)
         msg "Logging set to ${LOG_FORMAT_NAME}"
 
-        if [ "${NO_LOGGING_URL_PARAMS}" ]; then
+        if [ "${NO_LOGGING_URL_PARAMS:-}" == TRUE ]; then
             sed -i -e 's/\$request_uri/\$uri/g' ${NGIX_CONF_DIR}/logging.conf
         fi
 
-        if [ "${NO_LOGGING_BODY}" == "TRUE" ]; then
+        if [ "${NO_LOGGING_BODY:-}" == TRUE ]; then
             sed --in-place '/\$request_body/d' ${NGIX_CONF_DIR}/logging.conf
         fi
 
-        if [ "${NO_LOGGING_RESPONSE}" == "TRUE" ]; then
+        if [ "${NO_LOGGING_RESPONSE:-}" == TRUE ]; then
             sed --in-place '/\$response_body/d' ${NGIX_CONF_DIR}/logging.conf
             touch ${NGIX_CONF_DIR}/response_body.conf
         else
@@ -160,18 +157,18 @@ case "${LOG_FORMAT_NAME}" in
     ;;
 esac
 
-if [ "${ADD_NGINX_SERVER_CFG}" != "" ]; then
+if [ -n "${ADD_NGINX_SERVER_CFG:-}" ]; then
     msg "Adding extra config for server context."
     echo ${ADD_NGINX_SERVER_CFG}>${NGIX_CONF_DIR}/nginx_server_extras.conf
 fi
 
-if [ "${ADD_NGINX_HTTP_CFG}" != "" ]; then
+if [ -n "${ADD_NGINX_HTTP_CFG:-}" ]; then
     msg "Adding extra config for http context."
     echo ${ADD_NGINX_HTTP_CFG}>${NGIX_CONF_DIR}/nginx_http_extras.conf
 fi
 
 GEO_CFG="${NGIX_CONF_DIR}/nginx_geoip.conf"
-if [ "${ALLOW_COUNTRY_CSV}" != "" ]; then
+if [ -n "${ALLOW_COUNTRY_CSV:-}" ]; then
     msg "Enabling Country codes detection:${ALLOW_COUNTRY_CSV}..."
 	cat > ${NGIX_CONF_DIR}/nginx_geoip_init.conf <<-EOF-GEO-INIT
 	init_by_lua '

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -6,6 +6,7 @@ else
     uuid.randomseed(socket.gettime()*10000)
     local uuid_str = uuid()
     ngx.var.uuid = uuid_str
-    ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
+    local uuid_var_name = os.getenv("UUID_VAR_NAME")
+    ngx.var.uuid_log_opt = " " .. uuid_var_name .. "=" .. uuid_str
     return uuid_str
 end

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,7 @@
 error_log /dev/stderr error;
 
 env LOG_UUID;
+env UUID_VAR_NAME;
 env HTTPS_REDIRECT_PORT_STRING;
 env ALLOW_COUNTRY_CSV;
 env VERBOSE_ERROR_PAGES;


### PR DESCRIPTION
Some miscellaneous additions from your friends at GDS

* Some bash tidyups
* Support for pulling rulesets from S3
* Support for custom log formats
* Support for custom UUID variable names

Also, this fixes the behaviour of `DISABLE_SYSDIG_METRICS` which I don't think worked (untested, but looks like it from code inspection)