### PR TITLE
Allow customisation of the request ID header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Variables to control how to configure the proxy (can be set per location, see
 * `EXTRA_NAXSI_RULES` - Allows NAXSI rules to be specified as an environment variable. This allows one or two extra
 rules to be specified without downloading or mounting in a rule file.
 * `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file.
-* `ENABLE_UUID_PARAM` - If set to "FALSE", will NOT add a UUID url parameter to all requests. The Default will add this
- for easy tracking in down stream logs e.g. `nginxId=50c91049-667f-4286-c2f0-86b04b27d3f0`.
- If set to `HEADER` it will add `nginxId` to the headers, not append to the get params.
+* `ENABLE_UUID_PARAM` - By default, a unique request ID will be generated and added to all requests as a query parameter to aid in tracing requests.
+ If set to `HEADER` it will add a HTTP header to all requests instead. The name of the parameter or header is taken from `UUID_VAR_NAME`.
+ Set to `FALSE` to disable this behaviour.
+* `UUID_VAR_NAME` - The name of the query parameter or header (see `ENABLE_UUID_PARAM`) to use for the unique request ID. Defaults to `nginxId`.
 * `CLIENT_CERT_REQUIRED` - if set to `TRUE`, will deny access at this location, see [Client Certs](#client-certs).
 * `VERIFY_SERVER_CERT` - if set to `TRUE`, will verify the upstream server's TLS certificate is valid and signed by the CA, see [Verifying Upstream Server](#verifying-upstream-server).
 * `USE_UPSTREAM_CLIENT_CERT` - if set to `TRUE`, will use the set of upstream client certs when connecting upstream, see [Upstream Client Certs](#upstream-client-certs).

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -553,6 +553,28 @@ else
   echo "Testing VERBOSE_ERROR_PAGES works..."
 fi
 
+start_test "Test setting UUID name works..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=custom_uuid_name\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "custom_uuid_name"
+echo "Testing setting UUID_VAR_NAME works"
+
+start_test "Test setting empty UUID name defaults correctly..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "nginxId"
+echo "Testing UUID_VAR_NAME default if empty works"
+
 echo "_________________________________"
 echo "We got here, ALL tests successful"
 clean_up

--- a/defaults.sh
+++ b/defaults.sh
@@ -2,6 +2,7 @@
 export NGIX_CONF_DIR=/usr/local/openresty/nginx/conf
 export NGINX_BIN=/usr/local/openresty/nginx/sbin/nginx
 export UUID_FILE=/tmp/uuid_on
+export UUID_VAR_NAME=${UUID_VAR_NAME:-'nginxId'}
 export DEFAULT_ERROR_CODES="500 501 502 503 504"
 export LOG_FORMAT_NAME=${LOG_FORMAT_NAME:-json}
 export SERVER_CERT=${SERVER_CERT:-/etc/keys/crt}

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -147,12 +147,12 @@ if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
     UUID_ARGS=''
     msg "Auto UUID request parameter disabled for location ${LOCATION_ID}."
 elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
-    UUID_ARGS='proxy_set_header nginxId $uuidopt;'
+    UUID_ARGS="proxy_set_header ${UUID_VAR_NAME} \$uuidopt;"
     # Ensure nginx enables this globaly
     msg "Auto UUID request header enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}
 else
-    UUID_ARGS='if ($is_args) {set $args $args&nginxId=$uuidopt;} if ($is_args = "") { set $args nginxId=$uuidopt;}'
+    UUID_ARGS="if (\$is_args) {set \$args \$args&${UUID_VAR_NAME}=\$uuidopt;} if (\$is_args = \"\") { set \$args ${UUID_VAR_NAME}=\$uuidopt;}"
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -2,15 +2,16 @@ if os.getenv("LOG_UUID") == "FALSE" then
     return ""
 else
     local uuid_str = ""
-    if ngx.req.get_headers()["nginxId"] == nil then
+    local uuid_var_name = os.getenv("UUID_VAR_NAME")
+    if ngx.req.get_headers()[uuid_var_name] == nil then
         local socket = require("socket")
         local uuid = require("uuid")
         uuid.randomseed(socket.gettime()*10000)
         uuid_str = uuid()
     else
-	uuid_str = ngx.req.get_headers()["nginxId"]
+        uuid_str = ngx.req.get_headers()[uuid_var_name]
     end
     ngx.var.uuid = uuid_str
-    ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
+    ngx.var.uuid_log_opt = " " .. uuid_var_name .. "=" .. uuid_str
     return uuid_str
 end

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,7 @@
 error_log /dev/stderr error;
 
 env LOG_UUID;
+env UUID_VAR_NAME;
 env HTTPS_REDIRECT_PORT_STRING;
 env ALLOW_COUNTRY_CSV;
 env VERBOSE_ERROR_PAGES;


### PR DESCRIPTION
Allow the default of 'nginxId' to be overridden via the UUID_VAR_NAME
environment variable

Update the documentation for `ENABLE_UUID_PARAM` to clarify the new behaviour.