### PR TITLE
Add support for custom logging formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ managed by Docker or Kubernetes.
 * `CLIENT_MAX_BODY_SIZE` - Can set a larger upload than Nginx defaults in MB.
 * `HTTPS_REDIRECT_PORT` - Only required for http to https redirect and only when a non-standard https port is in use.
 This is useful when testing or for development instances or when a load-balancer mandates a non-standard port.
-* `LOG_FORMAT_NAME` - Can be set to `text` or `json` (default).
+* `LOG_FORMAT_NAME` - Can be set to `text`, `json` (default) or `custom`.
 * `NO_LOGGING_URL_PARAMS` - Can be set to `TRUE` if you don't want to log url params. Default is empty which means URL params are logged
 * `NO_LOGGING_BODY` - Defaults to true `TRUE`.  Set otherwise and nginx should log the request_body.
 * `NO_LOGGING_RESPONSE` - Defaults to true `TRUE`.  Set otherwise and nginx should log the response_body
+* `CUSTOM_LOG_FORMAT` - When `LOG_FORMAT_NAME` is set to `custom`, the log format to use
 * `SERVER_CERT` - Can override where to find the server's SSL cert.
 * `SERVER_KEY` - Can override where to find the server's SSL key.
 * `SSL_CIPHERS` - Change the SSL ciphers support default only AES256+EECDH:AES256+EDH:!aNULL

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -447,6 +447,17 @@ echo "Testing json logs format..."
 docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 docker logs ${INSTANCE}  | grep 'animal=cow'
 
+start_test "Test custom logging format..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
+           -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"LOG_FORMAT_NAME=custom\" \
+           -e \"CUSTOM_LOG_FORMAT=' \\\$host:\\\$server_port \\\$uuid \\\$http_x_forwarded_for \\\$remote_addr \\\$remote_user [\\\$time_local] \\\$request \\\$status \\\$body_bytes_sent \\\$request_time \\\$http_x_forwarded_proto \\\$http_referer \\\$http_user_agent '\" \
+           -e \"ENABLE_UUID_PARAM=FALSE\" \
+           --link \"${MOCKSERVER}:${MOCKSERVER}\" "
+wget -O /dev/null --quiet --no-check-certificate --header="Host: example.com" https://${DOCKER_HOST_NAME}:${PORT}?animal=cow
+echo "Testing custom logs format..."
+docker logs ${INSTANCE} | egrep '^\{\sexample\.com:10443.*\[.*\]\sGET\s\/\?animal\=cow\sHTTP/[0-9]\.[0-9]\s200.*\s\}$'
 
 start_test "Test param logging off option works..." "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \


### PR DESCRIPTION
To specify a custom log format, set LOG_FORMAT_NAME to 'custom' and set
CUSTOM_LOG_FORMAT to a valid nginx log_format. The log format within the nginx
configuration will be named 'extended_custom'