### PR TITLE
Support downloading naxsi rules from Amazon S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Note the following variables can only be set once:
 [Arbitrary Config](#arbitrary-config)
 * `ADD_NGINX_HTTP_CFG` - Arbitrary extra NGINX configuration to be added to the http context, see
 [Arbitrary Config](#arbitrary-config)
+* `AWS_REGION` - Sets the AWS region this container is running in. Used to construct urls from which to download resources from. Defaults to 'eu-west-1' if not set.
+* `DOWNLOAD_VIA_S3_VPC_ENDPOINT` - Set to `TRUE` to download rules from S3. Default is `FALSE`.
 * `LOCATIONS_CSV` - Set to a list of locations that are to be independently proxied, see the example
 [Using Multiple Locations](#using-multiple-locations). Note, if this isn't set, `/` will be used as the default
 location.

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export DOWNLOAD_VIA_S3_VPC_ENDPOINT=${DOWNLOAD_VIA_S3_VPC_ENDPOINT:-FALSE}
 export NGIX_CONF_DIR=/usr/local/openresty/nginx/conf
 export NGINX_BIN=/usr/local/openresty/nginx/sbin/nginx
 export UUID_FILE=/tmp/uuid_on
@@ -15,6 +16,7 @@ export NO_LOGGING_BODY=${NO_LOGGING_BODY:-'TRUE'}
 export NO_LOGGING_RESPONSE=${NO_LOGGING_RESPONSE:-'TRUE'}
 export STATSD_METRICS_ENABLED=${STATSD_METRICS:-'TRUE'}
 export STATSD_SERVER=${STATSD_SERVER:-'127.0.0.1'}
+export AWS_REGION=${AWS_REGION:-eu-west-1}
 
 export HTTPS_REDIRECT_PORT_STRING=":${HTTPS_REDIRECT_PORT}"
 if [ "${HTTPS_REDIRECT_PORT_STRING}" == ":" ]; then
@@ -39,7 +41,10 @@ function download() {
             msg "About to retry download for ${file_url}..."
             sleep 1
         fi
-        if curl --max-time 30 --fail -s -o ${file_path} ${file_url} ; then
+        if [ "$DOWNLOAD_VIA_S3_VPC_ENDPOINT" == TRUE ]; then
+            aws s3 cp --region "$AWS_REGION" --endpoint-url https://s3-"$AWS_REGION".amazonaws.com "$NAXSI_RULES_URL_CSV" "$file_path"
+            error=$?
+        elif curl --max-time 30 --fail -s -o ${file_path} ${file_url} ; then
             error=0
         fi
         if [ -n ${file_md5} ]; then


### PR DESCRIPTION
Add AWS_REGION (defaults to eu-west-1) and DOWNLOAD_VIA_S3_VPC_ENDPOINT
(defaults to FALSE) to enable downloading naxsi rules from S3