### PR TITLE
add option to disable default security headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ADD ./go.sh /
 ADD ./enable_location.sh /
 ADD ./location_template.conf /
 ADD ./logging.conf /usr/local/openresty/nginx/conf/
+ADD ./security_defaults.conf /usr/local/openresty/nginx/conf/
 ADD ./html/ /usr/local/openresty/nginx/html/
 ADD ./readyness.sh /
 ADD ./helper.sh /

--- a/go.sh
+++ b/go.sh
@@ -77,10 +77,12 @@ if [ -z ${DISABLE_SYSDIG_METRICS+x} ]; then
 EOF-SYSDIG-SERVER
 fi
 
-IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
-for i in "${!LOCATIONS_ARRAY[@]}"; do
-    /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}
-done
+if [ "${CUSTOM_PROXY_CONFIG}" != "TRUE" ]; then
+  IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
+  for i in "${!LOCATIONS_ARRAY[@]}"; do
+      /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}
+  done
+fi
 
 if [ "${NAME_RESOLVER}" == "" ]; then
     if [ "${DNSMASK}" == "TRUE" ]; then

--- a/go.sh
+++ b/go.sh
@@ -35,6 +35,11 @@ cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 		listen localhost:${INTERNAL_LISTEN_PORT} ssl;
 EOF-LISTEN
 
+if [ "${CUSTOM_SECURITY_DEFAULTS}" == "TRUE" ]; then
+    msg "Disabling inbuilt security headers add per location"
+    > /usr/local/openresty/nginx/conf/security_defaults.conf
+fi
+
 if [ "${LOAD_BALANCER_CIDR}" != "" ]; then
     msg "Using proxy_protocol from '$LOAD_BALANCER_CIDR' (real client ip is forwarded correctly by loadbalancer)..."
     export REMOTE_IP_VAR="proxy_protocol_addr"

--- a/nginx.conf
+++ b/nginx.conf
@@ -81,24 +81,7 @@ http {
     include /usr/local/openresty/nginx/conf/upload_size*.conf;
     include /usr/local/openresty/nginx/conf/nginx_http_extras*.conf;
 
-    # config to not allow the browser to render the page inside an frame or iframe
-    # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
-    add_header X-Frame-Options SAMEORIGIN;
-
-    # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
-    # to disable content-type sniffing on some browsers.
-    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-    add_header X-Content-Type-Options nosniff;
-
-    # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-    # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
-    # this particular website if it was disabled by the user.
-    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-    add_header X-XSS-Protection "1; mode=block";
-
-    # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
-    # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+    include /usr/local/openresty/nginx/conf/security_defaults.conf;
 
   # Accept underscores in headers as NAXSI does this
   underscores_in_headers on;

--- a/security_defaults.conf
+++ b/security_defaults.conf
@@ -1,0 +1,19 @@
+
+    # config to not allow the browser to render the page inside an frame or iframe
+    # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+    add_header X-Frame-Options SAMEORIGIN;
+
+    # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
+    # to disable content-type sniffing on some browsers.
+    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    add_header X-Content-Type-Options nosniff;
+
+    # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
+    # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
+    # this particular website if it was disabled by the user.
+    # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    add_header X-XSS-Protection "1; mode=block";
+
+    # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+    # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";


### PR DESCRIPTION
This is a patch to allow the custom security headers to be disabled. This is because having them here interferes if you want different headers on the individual proxy locations.

set CUSTOM_SECURITY_DEFAULTS to TRUE in order to disable including the existing security headers, anything else keeps them as current.