### PR TITLE
add option to override proxy logic

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -72,10 +72,12 @@ if [ -z ${DISABLE_SYSDIG_METRICS+x} ]; then
 EOF-SYSDIG-SERVER
 fi
 
-IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
-for i in "${!LOCATIONS_ARRAY[@]}"; do
-    /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}
-done
+if [ "${CUSTOM_PROXY_CONFIG}" != "TRUE" ]; then
+  IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
+  for i in "${!LOCATIONS_ARRAY[@]}"; do
+      /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}
+  done
+fi
 
 if [ "${NAME_RESOLVER}" == "" ]; then
     if [ "${DNSMASK}" == "TRUE" ]; then


### PR DESCRIPTION
We would like to option to ignore the current proxy handling logic for more complicated setups.
By setting CUSTOM_PROXY_CONFIG to TRUE the enable_locations.sh script is not called.

This allows users to load via a configmap their own proxy logic into the locations folder for inclusion into nginx.

