### PR TITLE
Allow for disabling of `ERROR_REDIRECT_CODES`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rules to be specified without downloading or mounting in a rule file.
 * `USE_UPSTREAM_CLIENT_CERT` - if set to `TRUE`, will use the set of upstream client certs when connecting upstream, see [Upstream Client Certs](#upstream-client-certs).
 * `ERROR_REDIRECT_CODES` - Can override when Nginx will redirect requests to its own error page. Defaults to
 "`500 501 502 503 504`". To support a new code, say `505`, an error page must be provided at
-`/usr/local/openresty/nginx/html/505.shtml`, see [Useful File Locations](#useful-file-locations).
+`/usr/local/openresty/nginx/html/505.shtml`, see [Useful File Locations](#useful-file-locations). Set to `FALSE` to disable all error pages.
 * `ADD_NGINX_LOCATION_CFG` - Arbitrary extra NGINX configuration to be added to the location context, see
 [Arbitrary Config](#arbitrary-config).
 * `PORT_IN_HOST_HEADER` - If FALSE will remove the port from the http `Host` header.

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -162,11 +162,13 @@ if [ "${ERROR_REDIRECT_CODES}" == "" ]; then
     ERROR_REDIRECT_CODES="${DEFAULT_ERROR_CODES}"
 fi
 ERROR_PAGES=""
-for code in ${ERROR_REDIRECT_CODES}; do
-  # Set up an individual error page for each code
-  msg "Enabling redirect on status code: ${code}"
-  ERROR_PAGES="${ERROR_PAGES} error_page ${code} /nginx-proxy/${code}.shtml;"
-done
+if [ "${ERROR_REDIRECT_CODES}" != "FALSE" ]; then
+    for code in ${ERROR_REDIRECT_CODES}; do
+      # Set up an individual error page for each code
+      msg "Enabling redirect on status code: ${code}"
+      ERROR_PAGES="${ERROR_PAGES} error_page ${code} /nginx-proxy/${code}.shtml;"
+    done
+fi
 
 if [ "${ENABLE_WEB_SOCKETS}" == "TRUE" ]; then
     msg "Enable web socket support"


### PR DESCRIPTION
Previously there was no way to completely disable nginx error pages, only to specify _alternate_ codes to redirect.

By checking for a value of `FALSE` before applying any error redirect functionality we can give services the option to completely disable nginx error pages, and always surface the application's own errors.