### PR TITLE
Use uuid from header if present

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -515,6 +515,17 @@ echo "Testing no logging of url params option works..."
 docker logs "${MOCKSERVER}" | grep 'Nginxid:'
 docker logs ${INSTANCE} | grep '"nginx_uuid": "'
 
+start_test "Test UUID header logging option passes through supplied value..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
+           -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           --link \"${MOCKSERVER}:${MOCKSERVER}\" "
+curl -sk -H "nginxId: 00000000-1111-2222-3333-444455556666" https://${DOCKER_HOST_NAME}:${PORT}
+echo "Testing no logging of url params option works..."
+docker logs "${MOCKSERVER}" | grep 'Nginxid:00000000-1111-2222-3333-444455556666'
+docker logs ${INSTANCE} | grep '"nginx_uuid": "00000000-1111-2222-3333-444455556666"'
+
 start_test "Test VERBOSE_ERROR_PAGES=TRUE displays debug info" "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://${MOCKSERVER}\" \
            -e \"PROXY_SERVICE_PORT=${MOCKSERVER_PORT}\" \

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -1,10 +1,15 @@
 if os.getenv("LOG_UUID") == "FALSE" then
     return ""
 else
-    local socket = require("socket")
-    local uuid = require("uuid")
-    uuid.randomseed(socket.gettime()*10000)
-    local uuid_str = uuid()
+    local uuid_str = ""
+    if ngx.req.get_headers()["nginxId"] == nil then
+        local socket = require("socket")
+        local uuid = require("uuid")
+        uuid.randomseed(socket.gettime()*10000)
+        uuid_str = uuid()
+    else
+	uuid_str = ngx.req.get_headers()["nginxId"]
+    end
     ngx.var.uuid = uuid_str
     ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
     return uuid_str


### PR DESCRIPTION
This enables tracking requests across microservices, provided the appropriate header is set on the outgoing HTTP request. Very useful for analysing performance problems. 

I've not done the work here to pull a UUID from the request parameter instead, but that should be a simple enough extension. 