### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/centos-base:latest
+FROM ubuntu:jammy
 
 ARG GEOIP_ACCOUNT_ID
 ARG GEOIP_LICENSE_KEY


### PR DESCRIPTION
quay.io/ukhomeofficedigital/centos-base:latest is a dead project and centos itself is now dead, move to ubuntu LTS