### PR TITLE
Upgrade OpenResty to 1.27.1.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,9 +17,9 @@ GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=Ge
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.3.tar.gz'
 GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.0/geoipupdate_7.1.0_linux_amd64.tar.gz'
 GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.6.0/libmaxminddb-1.6.0.tar.gz'
-LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.7.0.tar.gz'
-NAXSI_URL='https://github.com/nbs-system/naxsi/archive/1.3.tar.gz'
-OPEN_RESTY_URL='http://openresty.org/download/openresty-1.19.3.2.tar.gz'
+LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
+NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'
+OPEN_RESTY_URL='http://openresty.org/download/openresty-1.27.1.2.tar.gz'
 STATSD_URL='https://github.com/UKHomeOffice/nginx-statsd/archive/0.0.1-ngxpatch.tar.gz'
 
 MAXMIND_PATH='/usr/share/GeoIP'
@@ -95,12 +95,12 @@ popd
 
 echo "Install NAXSI default rules"
 mkdir -p /usr/local/openresty/naxsi/
-cp "./naxsi/naxsi_config/naxsi_core.rules" /usr/local/openresty/naxsi/
+cp "./naxsi/naxsi_rules/naxsi_core.rules" /usr/local/openresty/naxsi/
 
 echo "Installing luarocks"
 pushd luarocks
 ./configure --with-lua=/usr/local/openresty/luajit \
-            --lua-suffix=jit-2.1.0-beta2 \
+            --lua-suffix=jit-2.1 \
             --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1
 make build install
 popd


### PR DESCRIPTION
This upgrades OpenResty to version 1.27.1.2 and updates dependencies for compatibility. 

## Changes
- Upgrade OpenResty from 1.19.3.2 to 1.27.1.2 (nginx 1.19.3 -> 1.27.1).
- Upgrade NAXSI from 1.3 to 1.7 for nginx 1.27.1 compatibility (and use actively maintained wargio/naxsi fork).
- Upgrade LuaRocks from 3.7.0 to 3.12.0 for modern LuaJIT compatibility.
- Fix NAXSI rules path (naxsi_config -> naxsi_rules).
- Update LuaJIT suffix.