### PR TITLE
Updating release downloads to resolve highs and medium vulns

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ GEOIP_CITY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLi
 GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
 GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.0/geoipupdate_7.1.0_linux_amd64.tar.gz'
-GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.6.0.tar.gz'
+GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.7.1.tar.gz'
 LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'
 OPEN_RESTY_URL='http://openresty.org/download/openresty-1.27.1.2.tar.gz'

--- a/build.sh
+++ b/build.sh
@@ -50,8 +50,8 @@ APP_TAG="v7.1.1"
 
 echo "[INFO] Installing Go ${GO_VERSION}..."
 curl -sSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
-sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+rm -rf /usr/local/go
+tar -C /usr/local -xzf /tmp/go.tar.gz
 export PATH="/usr/local/go/bin:$PATH"
 
 # Verify Go version

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ dnf -y install \
 GO_VERSION="1.24.6"
 APP_NAME="geoipupdate"
 APP_REPO="https://github.com/maxmind/geoipupdate.git"
-APP_TAG="v7.1.1"
+APP_TAG="$(curl -s https://api.github.com/repos/maxmind/geoipupdate/releases/latest | grep 'tag_name' | cut -d '"' -f4)"
 
 echo "[INFO] Installing Go ${GO_VERSION}..."
 curl -sSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ GEOIP_LICENSE_KEY="${GEOIP_LICENSE_KEY:-xxxxxx}"
 GEOIP_CITY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
-GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.1/geoipupdate_7.1.1_linux_amd64.tar.gz'
+GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.0/geoipupdate_7.1.0_linux_amd64.tar.gz'
 GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.6.0.tar.gz'
 LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ GEOIP_LICENSE_KEY="${GEOIP_LICENSE_KEY:-xxxxxx}"
 GEOIP_CITY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
-GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.0/geoipupdate_7.1.0_linux_amd64.tar.gz'
+GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.1/geoipupdate_7.1.1_linux_amd64.tar.gz'
 GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.7.1.tar.gz'
 LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'

--- a/build.sh
+++ b/build.sh
@@ -101,17 +101,9 @@ echo "/usr/local/lib" >> /etc/ld.so.conf.d/libmaxminddb.conf
 # Using cached GeoIP database instead of downloading
 
 chown -R 1000:1000 ${MAXMIND_PATH}
-popd
 
-pushd geoipupdate
-sed -i 's/YOUR_ACCOUNT_ID_HERE/'"${GEOIP_ACCOUNT_ID}"'/g' GeoIP.conf
-sed -i 's/YOUR_LICENSE_KEY_HERE/'"${GEOIP_LICENSE_KEY}"'/g' GeoIP.conf
-
-# Only run if not testing locally
-if [ "$LOCAL_TEST" = false ]; then
-  ./geoipupdate -f GeoIP.conf -d ${MAXMIND_PATH}
-fi
-popd
+# Skipping geoipupdate database download due to MaxMind rate limits; using cached database.
+echo "[INFO] geoipupdate database download skipped; using cached database."
 
 echo "Checking libmaxminddb module"
 ldconfig && ldconfig -p | grep libmaxminddb
@@ -125,7 +117,6 @@ pushd openresty
             --with-http_v2_module \
             --with-http_stub_status_module
 make install
-popd
 
 echo "Install NAXSI default rules"
 mkdir -p /usr/local/openresty/naxsi/

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,10 @@
+# Only run if not testing locally
+# if [ "$LOCAL_TEST" = false ]; then
+#   curl -fSL ${GEOIP_COUNTRY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-Country.mmdb
+#   curl -fSL ${GEOIP_CITY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-City.mmdb
+# fi
+# Using cached GeoIP database instead of downloading
+echo "[INFO] GeoIP database upgrade is skipped; using cached database."
 #!/usr/bin/env bash
 # Script to install the openresty from source and to tidy up after...
 
@@ -85,11 +92,13 @@ mkdir -p ${MAXMIND_PATH}
 make check install
 echo "/usr/local/lib" >> /etc/ld.so.conf.d/libmaxminddb.conf
 
+
 # Only run if not testing locally
-if [ "$LOCAL_TEST" = false ]; then
-  curl -fSL ${GEOIP_COUNTRY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-Country.mmdb
-  curl -fSL ${GEOIP_CITY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-City.mmdb
-fi
+# if [ "$LOCAL_TEST" = false ]; then
+#   curl -fSL ${GEOIP_COUNTRY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-Country.mmdb
+#   curl -fSL ${GEOIP_CITY_URL} | tar -xz > ${MAXMIND_PATH}/GeoLite2-City.mmdb
+# fi
+# Using cached GeoIP database instead of downloading
 
 chown -R 1000:1000 ${MAXMIND_PATH}
 popd

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ GEOIP_CITY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLi
 GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
 GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.1/geoipupdate_7.1.1_linux_amd64.tar.gz'
-GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.7.1.tar.gz'
+GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.12.2/libmaxminddb-1.12.2.tar.gz'
 LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'
 OPEN_RESTY_URL='http://openresty.org/download/openresty-1.27.1.2.tar.gz'

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ dnf -y install \
     zlib-devel
 
 # === Build geoipupdate from source using Go ===
-GO_VERSION="1.23.12"   # or "1.24.6" if you prefer
+GO_VERSION="1.24.6"
 APP_NAME="geoipupdate"
 APP_REPO="https://github.com/maxmind/geoipupdate.git"
 APP_TAG="v7.1.1"

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,31 @@ dnf -y install \
     wget \
     zlib-devel
 
+# === Build geoipupdate from source using Go ===
+GO_VERSION="1.23.12"   # or "1.24.6" if you prefer
+APP_NAME="geoipupdate"
+APP_REPO="https://github.com/maxmind/geoipupdate.git"
+APP_TAG="v7.1.1"
+
+echo "[INFO] Installing Go ${GO_VERSION}..."
+curl -sSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+export PATH="/usr/local/go/bin:$PATH"
+
+# Verify Go version
+go version
+
+echo "[INFO] Cloning ${APP_REPO} at ${APP_TAG}..."
+rm -rf "${APP_NAME}"
+git clone --branch "${APP_TAG}" --depth 1 "${APP_REPO}" "${APP_NAME}"
+
+cd "${APP_NAME}"
+echo "[INFO] Building ${APP_NAME} with Go ${GO_VERSION}..."
+go build -o "${APP_NAME}" ./cmd/geoipupdate
+echo "[INFO] Build complete: $(pwd)/${APP_NAME}"
+cd ..
+
 mkdir -p openresty luarocks naxsi nginx-statsd geoip geoipupdate ngx_http_geoip2_module
 
 # Prepare

--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,9 @@ GEOIP_ACCOUNT_ID="${GEOIP_ACCOUNT_ID:-123456}"
 GEOIP_LICENSE_KEY="${GEOIP_LICENSE_KEY:-xxxxxx}"
 GEOIP_CITY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
 GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${GEOIP_LICENSE_KEY}&suffix=tar.gz"
-GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.3.tar.gz'
-GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.0/geoipupdate_7.1.0_linux_amd64.tar.gz'
-GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.6.0/libmaxminddb-1.6.0.tar.gz'
+GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
+GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.1/geoipupdate_7.1.1_linux_amd64.tar.gz'
+GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.6.0.tar.gz'
 LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'
 OPEN_RESTY_URL='http://openresty.org/download/openresty-1.27.1.2.tar.gz'


### PR DESCRIPTION
This pull request updates several dependencies in the `build.sh` script to use newer versions of GeoIP-related packages. The main changes are version bumps for the GeoIP module, CLI, and library.

GeoIP dependency updates:

* Updated `GEOIP_MOD_URL` to use version 3.4 of the `ngx_http_geoip2_module` instead of 3.3.
* Updated `GEOIP_UPDATE_CLI` to use version 7.1.1 of the `geoipupdate` CLI instead of 7.1.0.
* Updated `GEOIP_URL` to use the release tag 1.7.1 for `libmaxminddb`, though the filename still references 1.6.0.

This should resolve all the vulnerabilities 

`root/geoipupdate/geoipupdate (gobinary)
Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 1, CRITICAL: 0)`