### PR TITLE
ACPENG-2940: Update docker-nginx-proxy image and fix publish script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:10.0
+FROM almalinux:10.1
 
 RUN dnf update -y && \
     dnf autoremove -y && \

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ GEOIP_COUNTRY_URL="https://download.maxmind.com/app/geoip_download?edition_id=Ge
 GEOIP_MOD_URL='https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz'
 GEOIP_UPDATE_CLI='https://github.com/maxmind/geoipupdate/releases/download/v7.1.1/geoipupdate_7.1.1_linux_amd64.tar.gz'
 GEOIP_URL='https://github.com/maxmind/libmaxminddb/releases/download/1.12.2/libmaxminddb-1.12.2.tar.gz'
-LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.12.0.tar.gz'
+LUAROCKS_URL='https://luarocks.github.io/luarocks/releases/luarocks-3.13.0.tar.gz'
 NAXSI_URL='https://github.com/wargio/naxsi/releases/download/1.7/naxsi-1.7-src-with-deps.tar.gz'
 OPEN_RESTY_URL='http://openresty.org/download/openresty-1.27.1.2.tar.gz'
 STATSD_URL='https://github.com/UKHomeOffice/nginx-statsd/archive/0.0.1-ngxpatch.tar.gz'

--- a/publish.sh
+++ b/publish.sh
@@ -32,10 +32,6 @@ check_arg "${SRC}" "SRC"
 check_arg "${DEST}" "DEST"
 check_arg "${VERSION}" "VERSION"
 
-PATCH="${VERSION}"
-MINOR=`echo ${PATCH} | awk -F '.' '{print $1"."$2}'`
-MAJOR=`echo ${MINOR} | awk -F '.' '{print $1}'`
-
 tag_n_push() {
     FULL_NAME="${DEST}:${1}"
     echo -n "Publishing '${SRC}' as '${FULL_NAME}'..."
@@ -44,7 +40,4 @@ tag_n_push() {
     echo " done."
 }
 
-tag_n_push "${PATCH}"
-tag_n_push "${MINOR}"
-tag_n_push "${MAJOR}"
-#tag_n_push "latest"
+tag_n_push "${VERSION}"


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2940

I've bumped AlmaLinux and LuaRocks to the latest versions. Also I've updated publish.sh to only push the exact tag rather than also pushing minor and major version tags as a best practice.